### PR TITLE
ci(release): use npm bundled with Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-      - name: Install OIDC-capable npm
-        run: npm install --global npm@11.16.0
       - run: pnpm install --frozen-lockfile
       - id: release
         run: >-


### PR DESCRIPTION
- Remove the redundant pinned npm installation.
- Use the OIDC-capable npm version bundled with Node 24.