### PR TITLE
chore: add The Company Company environment config

### DIFF
--- a/.company/environment.json
+++ b/.company/environment.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://api.thecompany.company/schemas/v1/environment.json",
+	"scripts": {
+		"install": {
+			"command": "set -euo pipefail\nexport DEBIAN_FRONTEND=noninteractive\nsudo apt-get update -y\nsudo apt-get install -y --no-install-recommends ca-certificates curl gnupg\ncurl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -\nsudo apt-get install -y --no-install-recommends nodejs\nsudo corepack enable\npnpm install --frozen-lockfile\npnpm build",
+			"timeout": 1800
+		},
+		"prepare": {
+			"command": "set -euo pipefail\npnpm install --frozen-lockfile",
+			"timeout": 600
+		}
+	},
+	"env": {
+		"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+	}
+}


### PR DESCRIPTION
Adds `.company/environment.json` so The Company Company can build and run this repo in cloud environments.

- `install`: Node 22 via NodeSource, pnpm via corepack, `pnpm install --frozen-lockfile`, `pnpm build`
- `prepare`: fast idempotent `pnpm install --frozen-lockfile`
- `env`: non-interactive corepack

Verified by running the install command to exit 0 in a clean Ubuntu 24.04 sandbox.